### PR TITLE
Allow settings tokens via URL query parameters and fix unidiomatic use of RxJS

### DIFF
--- a/src/main/angular/src/app/assignment/assignment.service.ts
+++ b/src/main/angular/src/app/assignment/assignment.service.ts
@@ -155,11 +155,11 @@ export class AssignmentService {
     );
   }
 
-  getNext(course: Course, assignment: Assignment): Observable<Assignment | null> {
+  getNext(course: Course, assignment: Assignment): Observable<Assignment | undefined> {
     const ids = course.assignmentIds!;
     const index = ids.indexOf(assignment.id!);
     if (index < 0 || index + 1 >= ids.length) {
-      return of(null);
+      return of(undefined);
     }
 
     const nextID = ids[index + 1];

--- a/src/main/angular/src/app/assignment/course/course.component.ts
+++ b/src/main/angular/src/app/assignment/course/course.component.ts
@@ -5,6 +5,7 @@ import {CourseService} from '../course.service';
 import Assignment from '../model/assignment';
 import {AssignmentService} from '../assignment.service';
 import {SolutionService} from '../solution.service';
+import {switchMap, tap} from 'rxjs/operators';
 
 @Component({
   selector: 'app-course',
@@ -28,37 +29,38 @@ export class CourseComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.activatedRoute.params.subscribe(params => {
-      this.assignmentID = params.aid;
+    this.activatedRoute.params.pipe(
+      tap(params => {
+        this.assignmentID = params.aid;
+        this.courseID = params.cid;
+      }),
+      switchMap(params => this.courseService.get(params.cid)),
+    ).subscribe(course => {
+      this.course = course;
 
-      const courseID: string = params.cid;
-      this.courseID = courseID;
-      this.courseService.get(courseID).subscribe(course => {
-        this.course = course;
+      const assignmentIds = course.assignmentIds!;
+      if (!this.assignmentID) {
+        const firstAssignment = assignmentIds[0];
+        this.router.navigate(['assignments', 'courses', course.id, 'assignments', firstAssignment]);
+        return;
+      }
 
-        const assignmentIds = course.assignmentIds!;
-        if (!this.assignmentID) {
-          const firstAssignment = assignmentIds[0];
-          this.router.navigate(['assignments', 'courses', courseID, 'assignments', firstAssignment]);
+      const solutions = this.solutionService.getOwnIds();
+      this.latestSolutionIDs = new Array<string>(assignmentIds.length);
+
+      course.assignments = new Array<Assignment>(assignmentIds.length);
+      for (let i = 0; i < assignmentIds.length; i++) {
+        const id = assignmentIds[i];
+        this.assignmentService.get(id).subscribe(assignment => {
+          course.assignments![i] = assignment;
+        });
+
+        const lastSolutionID = solutions.find(({assignment}) => id === assignment);
+        if (lastSolutionID) {
+          this.latestSolutionIDs[i] = lastSolutionID.id;
         }
-
-        const solutions = this.solutionService.getOwnIds();
-        this.latestSolutionIDs = new Array<string>(assignmentIds.length);
-
-        course.assignments = new Array<Assignment>(assignmentIds.length);
-        for (let i = 0; i < assignmentIds.length; i++) {
-          const id = assignmentIds[i];
-          this.assignmentService.get(id).subscribe(assignment => {
-            course.assignments![i] = assignment;
-          });
-
-          const lastSolutionID = solutions.find(({assignment}) => id === assignment);
-          if (lastSolutionID) {
-            this.latestSolutionIDs[i] = lastSolutionID.id;
-          }
-        }
-      });
-    })
+      }
+    });
   }
 
   getBadgeColor(index: number, assignment: Assignment) {

--- a/src/main/angular/src/app/assignment/create-course/create-course.component.ts
+++ b/src/main/angular/src/app/assignment/create-course/create-course.component.ts
@@ -1,7 +1,7 @@
 import {Component, Inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
-import {Observable} from 'rxjs';
+import {forkJoin, Observable} from 'rxjs';
 import {debounceTime, distinctUntilChanged, map} from 'rxjs/operators';
 
 import {DragulaService} from 'ng2-dragula';
@@ -87,13 +87,9 @@ export class CreateCourseComponent implements OnInit, OnDestroy {
     this.title = course.title;
     this.description = course.description;
 
-    const assignmentIds = course.assignmentIds!;
-    this.assignments = new Array<Assignment>(assignmentIds.length);
-    for (let i = 0; i < assignmentIds.length; i++) {
-      this.assignmentService.get(assignmentIds[i]).subscribe(assignment => {
-        this.assignments[i] = assignment;
-      });
-    }
+    forkJoin(course.assignmentIds!.map(id => this.assignmentService.get(id))).subscribe(assignments => {
+      this.assignments = assignments;
+    })
   }
 
   loadDraft(): void {

--- a/src/main/angular/src/app/assignment/solution-table/solution-table.component.ts
+++ b/src/main/angular/src/app/assignment/solution-table/solution-table.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
-import {Observable} from 'rxjs';
+import {ActivatedRoute, Router} from '@angular/router';
+import {combineLatest, Observable} from 'rxjs';
 import {debounceTime, distinctUntilChanged, map} from 'rxjs/operators';
 
 import Assignment from '../model/assignment';
@@ -30,14 +30,18 @@ export class SolutionTableComponent implements OnInit {
 
   constructor(
     private activatedRoute: ActivatedRoute,
+    private router: Router,
     private assignmentService: AssignmentService,
     private solutionService: SolutionService,
   ) {
   }
 
   ngOnInit(): void {
-    this.activatedRoute.params.subscribe(params => {
+    combineLatest([this.activatedRoute.params, this.activatedRoute.queryParams]).subscribe(([params, query]) => {
       this.assignmentID = params.aid;
+      if (query.atok) {
+        this.assignmentService.setToken(params.aid, query.atok);
+      }
       this.loadAssignment();
       this.loadSolutions();
     });
@@ -163,7 +167,12 @@ export class SolutionTableComponent implements OnInit {
   }
 
   setToken(assignmentToken: string): void {
-    this.assignmentService.setToken(this.assignmentID, assignmentToken);
-    this.loadSolutions();
+    this.router.navigate([], {
+      relativeTo: this.activatedRoute,
+      queryParamsHandling: 'merge',
+      queryParams: {
+        atok: assignmentToken,
+      },
+    });
   }
 }


### PR DESCRIPTION
Improves many component implementations to use more idiomatic RxJS, namely avoid nesting `subscribe` calls and using `switchMap` and `forkJoin` where possible.

It was initially planned to introduce `unsubscribe` calls, but that was found to be [unnecessary](https://stackoverflow.com/questions/41138081/do-i-have-to-unsubscribe-from-activatedroute-e-g-params-observables).

## Improvements

* The query parameter `atok` can now be used to set the assignment token when viewing all solutions.
* The query parameters `atok` and `stok` can be now be used to set the assignment or solution token when viewing a solution.