### PR TITLE
Fix example selection

### DIFF
--- a/src/main/angular/src/app/four-pane-editor/four-pane-editor.component.ts
+++ b/src/main/angular/src/app/four-pane-editor/four-pane-editor.component.ts
@@ -55,8 +55,12 @@ export class FourPaneEditorComponent implements OnInit, OnDestroy {
     });
 
     this.activatedRoute.queryParams.subscribe(queryParams => {
-      const exampleName: string = queryParams.example;
-      this.selectedExample = exampleName ? this.examplesService.getExampleByName(exampleName) : this.scenarioEditorService.selectedExample;
+      const exampleName = queryParams.example;
+      if (exampleName) {
+        this.selectedExample = this.examplesService.getExampleByName(exampleName);
+      } else {
+        this.selectedExample = this.scenarioEditorService.selectedExample;
+      }
     });
   }
 
@@ -147,9 +151,8 @@ export class FourPaneEditorComponent implements OnInit, OnDestroy {
   }
 
   selectExample(value: Example | null): void {
-    this.selectedExample = value;
-    this.router.navigate([], {queryParams: {example: value?.name}});
     this.scenarioEditorService.selectedExample = value;
+    this.router.navigate([], {queryParams: {example: value?.name}});
   }
 
   private loadExample(value: Example | null): void {

--- a/src/main/angular/src/app/scenario-editor.service.ts
+++ b/src/main/angular/src/app/scenario-editor.service.ts
@@ -71,11 +71,7 @@ There is a Car with name Herbie.
 
   set selectedExample(example: Example | null) {
     this._selectedExample = example;
-    if (example) {
-      this.privacyService.setStorage('selectedExample', example.name);
-    } else {
-      localStorage.removeItem('selectedExample');
-    }
+    this.privacyService.setStorage('selectedExample', example ? example.name : null);
   }
 
   get autoSubmit(): boolean {


### PR DESCRIPTION
Selecting no example now correctly displays the stored scenario again. This was broken by 8fba606240bf77c7f161e18f7766b1840c446d83 - since PrivacyService now uses StorageService, values are stored in a cache which needs to be updated.

In addition, selecting an example no longer triggers submit twice.