### PR TITLE
Create temp dir for runcodegen

### DIFF
--- a/src/main/java/org/fulib/webapp/WebService.java
+++ b/src/main/java/org/fulib/webapp/WebService.java
@@ -92,6 +92,8 @@ public class WebService
 		service = Service.ignite();
 		service.port(4567);
 
+		new File(this.runCodeGen.getTempDir()).mkdirs();
+
 		service.staticFiles.externalLocation(this.runCodeGen.getTempDir());
 		service.staticFiles.expireTime(60 * 60);
 


### PR DESCRIPTION
Ensures the temporary directory used by runcodegen is always available by creating it if necessary. This prevents a bug where generated files would not be available.