### PR TITLE
Improved Assignment Editing

### DIFF
--- a/frontend/src/app/assignment/model/assignment.ts
+++ b/frontend/src/app/assignment/model/assignment.ts
@@ -9,7 +9,7 @@ export default class Assignment {
   createdBy?: string;
   author: string;
   email: string;
-  deadline?: Date;
+  deadline?: Date | string;
 
   classroom?: {
     link?: string;

--- a/frontend/src/app/assignment/pages/edit-assignment/edit-assignment.component.ts
+++ b/frontend/src/app/assignment/pages/edit-assignment/edit-assignment.component.ts
@@ -29,12 +29,12 @@ export class EditAssignmentComponent implements OnInit {
 
     this.route.params.pipe(
       switchMap(({aid}) => {
-        if (aid) {
-          return this.assignmentService.get(aid);
-        }
-        const draft = this.assignmentService.draft;
+        const draft = this.assignmentService.loadDraft(aid);
         if (draft) {
           return of(draft);
+        }
+        if (aid) {
+          return this.assignmentService.get(aid);
         }
         return of(this.createNew());
       }),
@@ -75,9 +75,7 @@ export class EditAssignmentComponent implements OnInit {
   }
 
   saveDraft(): void {
-    if (!this.context.assignment._id) {
-      this.assignmentService.draft = this.getAssignment();
-    }
+    this.assignmentService.saveDraft(this.context.assignment._id, this.getAssignment());
   }
 
   onImport(file: File): void {

--- a/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.html
+++ b/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.html
@@ -11,7 +11,7 @@
 </div>
 <app-edit-task-list
   *ngIf="markdown === undefined"
-  [tasks]="assignment.tasks"
+  [tasks]="context.assignment.tasks"
 ></app-edit-task-list>
 <app-autotheme-codemirror
   *ngIf="markdown !== undefined"

--- a/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.html
+++ b/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.html
@@ -17,7 +17,7 @@
   *ngIf="markdown !== undefined"
   [(content)]="markdown"
   [options]="{
-            mode: 'markdown',
+            mode: 'task-list',
             autoRefresh: true,
             lineNumbers: true
           }"

--- a/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.html
+++ b/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.html
@@ -22,4 +22,29 @@
             lineNumbers: true
           }"
 ></app-autotheme-codemirror>
+<div class="alert alert-info mt-3" *ngIf="markdown !== undefined">
+  <h4 class="alert-heading">
+    Syntax Help
+  </h4>
+  <ul>
+    <li>
+      Write each task on a new line.
+    </li>
+    <li>
+      Write parent tasks using Markdown headers:
+      <code>## Task 1 (15P)</code>
+    </li>
+    <li>
+      Use <code>###</code>, <code>####</code>, etc. for nesting.
+      The top level must use <code class="text-success">##</code> instead of <code class="text-danger">#</code>.
+    </li>
+    <li>
+      Write child tasks and deductions using Markdown list items:
+      <code>- Wrong format (-1P)</code>
+    </li>
+    <li>
+      (Optional) Specify a Task ID: <code>## Task 2 (10P) &lt;!--123abc--&gt;</code>
+    </li>
+  </ul>
+</div>
 <router-outlet></router-outlet>

--- a/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.ts
+++ b/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnDestroy} from '@angular/core';
 import Assignment from '../../../model/assignment';
 import {AssignmentContext} from '../../../services/assignment.context';
 import {TaskService} from '../../../services/task.service';
@@ -6,9 +6,9 @@ import {TaskService} from '../../../services/task.service';
 @Component({
   selector: 'app-edit-assignment-tasks',
   templateUrl: './tasks.component.html',
-  styleUrls: ['./tasks.component.scss']
+  styleUrls: ['./tasks.component.scss'],
 })
-export class TasksComponent implements OnInit {
+export class TasksComponent implements OnDestroy {
   assignment: Assignment;
   markdown?: string;
   saveDraft: () => void;
@@ -21,16 +21,17 @@ export class TasksComponent implements OnInit {
     this.saveDraft = context.saveDraft;
   }
 
-  ngOnInit(): void {
+  ngOnDestroy(): void {
+    this.switchMarkdown(false);
   }
 
   switchMarkdown(markdown: boolean) {
-    if (!markdown && this.markdown) {
+    if (markdown) {
+      this.markdown = this.taskService.renderTasks(this.assignment.tasks);
+    } else if (this.markdown !== undefined) {
       this.assignment.tasks = this.taskService.parseTasks(this.markdown);
       this.saveDraft();
       this.markdown = undefined;
-    } else {
-      this.markdown = this.taskService.renderTasks(this.assignment.tasks);
     }
   }
 

--- a/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.ts
+++ b/frontend/src/app/assignment/pages/edit-assignment/tasks/tasks.component.ts
@@ -1,5 +1,4 @@
 import {Component, OnDestroy} from '@angular/core';
-import Assignment from '../../../model/assignment';
 import {AssignmentContext} from '../../../services/assignment.context';
 import {TaskService} from '../../../services/task.service';
 
@@ -9,16 +8,12 @@ import {TaskService} from '../../../services/task.service';
   styleUrls: ['./tasks.component.scss'],
 })
 export class TasksComponent implements OnDestroy {
-  assignment: Assignment;
   markdown?: string;
-  saveDraft: () => void;
 
   constructor(
     private taskService: TaskService,
-    context: AssignmentContext,
+    public context: AssignmentContext,
   ) {
-    this.assignment = context.assignment;
-    this.saveDraft = context.saveDraft;
   }
 
   ngOnDestroy(): void {
@@ -27,10 +22,10 @@ export class TasksComponent implements OnDestroy {
 
   switchMarkdown(markdown: boolean) {
     if (markdown) {
-      this.markdown = this.taskService.renderTasks(this.assignment.tasks);
+      this.markdown = this.taskService.renderTasks(this.context.assignment.tasks);
     } else if (this.markdown !== undefined) {
-      this.assignment.tasks = this.taskService.parseTasks(this.markdown);
-      this.saveDraft();
+      this.context.assignment.tasks = this.taskService.parseTasks(this.markdown);
+      this.context.saveDraft();
       this.markdown = undefined;
     }
   }

--- a/frontend/src/app/assignment/services/assignment.service.ts
+++ b/frontend/src/app/assignment/services/assignment.service.ts
@@ -18,7 +18,6 @@ import Course from '../model/course';
   providedIn: 'root',
 })
 export class AssignmentService {
-  private _draft?: Assignment | null;
   private _cache = new Map<string, Assignment>();
 
   constructor(
@@ -31,20 +30,21 @@ export class AssignmentService {
 
   // --------------- Assignment Drafts ---------------
 
-  get draft(): Assignment | null {
-    if (typeof this._draft === 'undefined') {
-      const json = localStorage.getItem('assignmentDraft');
-      this._draft = json ? this.fromJson(json) : null;
-    }
-    return this._draft;
+  private getDraftKey(id?: string) {
+    return id ? `assignments/${id}/draft` : 'assignmentDraft';
   }
 
-  set draft(value: Assignment | null) {
-    this._draft = value;
+  loadDraft(id?: string): Assignment | undefined {
+    const stored = localStorage.getItem(this.getDraftKey(id));
+    return stored ? this.fromJson(stored) : undefined;
+  }
+
+  saveDraft(id?: string, value?: Assignment) {
+    const key = this.getDraftKey(id);
     if (value) {
-      localStorage.setItem('assignmentDraft', JSON.stringify(value));
+      localStorage.setItem(key, JSON.stringify(value));
     } else {
-      localStorage.removeItem('assignmentDraft');
+      localStorage.removeItem(key);
     }
   }
 

--- a/frontend/src/app/assignment/services/assignment.service.ts
+++ b/frontend/src/app/assignment/services/assignment.service.ts
@@ -36,7 +36,7 @@ export class AssignmentService {
 
   loadDraft(id?: string): Assignment | undefined {
     const stored = localStorage.getItem(this.getDraftKey(id));
-    return stored ? this.fromJson(stored) : undefined;
+    return stored ? JSON.parse(stored) : undefined;
   }
 
   saveDraft(id?: string, value?: Assignment) {
@@ -60,24 +60,10 @@ export class AssignmentService {
     this.storage.set(`assignmentToken/${id}`, token);
   }
 
-  // --------------- JSON Conversion ---------------
-
-  fromJson(json: string): Assignment {
-    const reviver = (k, v) => k === 'deadline' && v ? new Date(v) : v;
-    const data = JSON.parse(json, reviver);
-    const assignment = new Assignment();
-    Object.assign(assignment, data);
-    return assignment;
-  }
-
-  toJson(assignment: Assignment, space?: string): string {
-    return JSON.stringify(assignment, undefined, space);
-  }
-
   // --------------- Import/Export ---------------
 
   download(assignment: Assignment): void {
-    const json = this.toJson(assignment, '  ');
+    const json = JSON.stringify(assignment, undefined, '  ');
     saveAs(new Blob([json], {type: 'application/json'}), assignment.title + '.json');
   }
 
@@ -86,7 +72,7 @@ export class AssignmentService {
       const reader = new FileReader();
       reader.onload = _ => {
         const text = reader.result as string;
-        const assignment = this.fromJson(text);
+        const assignment = JSON.parse(text);
         subscriber.next(assignment);
       };
       reader.readAsText(file);

--- a/frontend/src/app/assignment/services/task.service.ts
+++ b/frontend/src/app/assignment/services/task.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from '@angular/core';
 import ObjectID from 'bson-objectid';
+import {TASK_ITEM_PATTERN, extractTaskItem} from '../../../modes/task-list-codemirror-mode';
 import {CreateEvaluationDto} from '../model/evaluation';
 import Task from '../model/task';
 
@@ -72,15 +73,14 @@ export class TaskService {
     // # Assignment 1 (xP/100P)
     // ## Task 1 (xP/30P)
     // - Something wrong (-1P)
-    const pattern = /(#+|-)\s+(.*)\s+\((?:[x\d]+P?\/)?(-?\d+)P?\)(?:\s*<!--([a-zA-Z0-9]+)-->)?/;
     const taskStack: Task[][] = [[]];
     for (const line of markdown.split('\n')) {
-      const match = line.match(pattern);
+      const match = line.match(TASK_ITEM_PATTERN);
       if (!match) {
         continue;
       }
 
-      const [, prefix, description, points, id] = match;
+      const {prefix, description, points, id} = extractTaskItem(match);
       const task: Task = {
         _id: id || this.generateID(),
         points: +points,

--- a/frontend/src/app/assignment/services/task.service.ts
+++ b/frontend/src/app/assignment/services/task.service.ts
@@ -72,7 +72,7 @@ export class TaskService {
     // # Assignment 1 (xP/100P)
     // ## Task 1 (xP/30P)
     // - Something wrong (-1P)
-    const pattern = /(#+|-)\s+(.*)\s+\((?:[x\d]+P?\/)?(-?\d+)P?\)(?:\s*<!--([a-zA-Z0-9])-->)?/;
+    const pattern = /(#+|-)\s+(.*)\s+\((?:[x\d]+P?\/)?(-?\d+)P?\)(?:\s*<!--([a-zA-Z0-9]+)-->)?/;
     const taskStack: Task[][] = [[]];
     for (const line of markdown.split('\n')) {
       const match = line.match(pattern);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,8 +18,10 @@ import * as CodeMirror from 'codemirror';
 import {AppModule} from './app/app.module';
 import {environment} from './environments/environment';
 import {SCENARIO_CODEMIRROR_MODE} from './modes/scenario-codemirror-mode';
+import {TASK_LIST_CODEMIRROR_MODE} from './modes/task-list-codemirror-mode';
 
 CodeMirror.defineSimpleMode('scenario', SCENARIO_CODEMIRROR_MODE);
+CodeMirror.defineSimpleMode('task-list', TASK_LIST_CODEMIRROR_MODE);
 
 import hljs from 'highlight.js/lib/core';
 import java from 'highlight.js/lib/languages/java';

--- a/frontend/src/modes/task-list-codemirror-mode.ts
+++ b/frontend/src/modes/task-list-codemirror-mode.ts
@@ -1,0 +1,15 @@
+import {Rule} from 'codemirror';
+
+export const TASK_ITEM_PATTERN = /(#+|-)(\s+)(.*)(\s+\((?:[x\d]+P?\/)?)(-?\d+)(P?\))(\s*<!--[a-zA-Z0-9]+-->)?/;
+
+export function extractTaskItem([_line, prefix, _1, description, _3, points, _4, id]: string[]) {
+  id = id?.trim()?.slice(4, -3);
+  return {prefix, description, points, id};
+}
+
+export const TASK_LIST_CODEMIRROR_MODE: { start: Rule[] } = {
+  start: [
+    {regex: TASK_ITEM_PATTERN, token: ['header', null!, 'string', null!, 'number', null!, 'meta']},
+    {regex: /.+/, token: 'error'},
+  ],
+};

--- a/frontend/src/modes/task-list-codemirror-mode.ts
+++ b/frontend/src/modes/task-list-codemirror-mode.ts
@@ -1,6 +1,6 @@
 import {Rule} from 'codemirror';
 
-export const TASK_ITEM_PATTERN = /(#+|-)(\s+)(.*)(\s+\((?:[x\d]+P?\/)?)(-?\d+)(P?\))(\s*<!--[a-zA-Z0-9]+-->)?/;
+export const TASK_ITEM_PATTERN = /(#{2,}|-)(\s+)(.*)(\s+\((?:[x\d]+P?\/)?)(-?\d+)(P?\))(\s*<!--[a-zA-Z0-9]+-->)?/;
 
 export function extractTaskItem([_line, prefix, _1, description, _3, points, _4, id]: string[]) {
   id = id?.trim()?.slice(4, -3);


### PR DESCRIPTION
## New Features

+ Added syntax highlighting when editing tasks as Markdown.
+ Added a syntax guide for editing tasks as Markdown.
+ Added saved drafts when editing existing assignments.

## Improvements

* Tasks with `#` are now ignored in the Markdown editor.

## Bugfixes

* Task IDs are now parsed correctly.
* Changed to tasks as Markdown are now applied when switching away from the Tasks tab.

Closes #<!-- issue number -->
