### PR TITLE
Multiline Evaluation Remarks

### DIFF
--- a/frontend/src/app/assignment/modules/assignment/submit.service.ts
+++ b/frontend/src/app/assignment/modules/assignment/submit.service.ts
@@ -109,8 +109,17 @@ export class SubmitService {
         const subTasks = renderSubTasks(task.children, depth + 1);
         return header + remark + snippets + subTasks;
       } else {
-        const desc = [task.description, evaluation?.remark].filter(x => x).join(': ');
-        return `- ${desc} (${point}P)\n${snippets}`;
+        let desc = task.description;
+        let remark = '';
+        if (evaluation && evaluation.remark) {
+          if (evaluation.remark.includes('\n')) {
+            remark = '\n  ' + evaluation.remark.trim().replace(/\n/g, '\n  ') + '\n';
+          } else {
+            desc = task.description ? `${task.description}: ${evaluation.remark}` : evaluation.remark;
+          }
+        }
+
+        return `- ${desc} (${point}P)\n${remark}${snippets}`;
       }
     };
 

--- a/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.html
+++ b/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.html
@@ -64,14 +64,31 @@
           </div>
           <div class="form-group">
             <label for="remarkInput">Remark</label>
-            <input
-              type="text" class="form-control" id="remarkInput"
+            <div class="input-group" *ngIf="!multilineRemark">
+              <input
+                type="text" class="form-control" id="remarkInput"
+                ngbAutofocus
+                [ngbTypeahead]="remarkTypeahead"
+                (focus)="remarkFocus$.next('')"
+                (click)="remarkFocus$.next('')"
+                [(ngModel)]="dto.remark"
+              >
+              <div class="input-group-append">
+                <button type="button" class="btn btn-outline-secondary" (click)="multilineRemark = 3">
+                  +
+                </button>
+              </div>
+            </div>
+            <textarea
+              *ngIf="multilineRemark"
+              class="form-control" id="remarkInput"
               ngbAutofocus
-              [ngbTypeahead]="remarkTypeahead"
-              (focus)="remarkFocus$.next('')"
-              (click)="remarkFocus$.next('')"
               [(ngModel)]="dto.remark"
-            >
+              [rows]="multilineRemark"
+            ></textarea>
+            <small class="form-text text-muted">
+              <a href="https://commonmark.org/help/">Markdown Syntax</a> is supported.
+            </small>
           </div>
           <div class="form-group">
             <label for="nameInput">Name</label>

--- a/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.html
+++ b/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.html
@@ -74,9 +74,12 @@
                 [(ngModel)]="dto.remark"
               >
               <div class="input-group-append">
-                <button type="button" class="btn btn-outline-secondary" (click)="multilineRemark = 3">
-                  +
-                </button>
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary bi-arrows-expand"
+                  (click)="multilineRemark = 3"
+                  ngbTooltip="Expand"
+                ></button>
               </div>
             </div>
             <textarea

--- a/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.ts
+++ b/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.ts
@@ -40,6 +40,7 @@ export class EvaluationModalComponent implements OnInit, OnDestroy {
   loggedIn = false;
   min?: number;
   max?: number;
+  multilineRemark = 0;
 
   originEvaluation?: Evaluation;
   originSolution?: Solution;
@@ -92,6 +93,7 @@ export class EvaluationModalComponent implements OnInit, OnDestroy {
           this.dto.points = evaluation.points;
           this.dto.remark = evaluation.remark;
           this.dto.snippets = evaluation.snippets;
+          this.multilineRemark = evaluation.remark.split('\n').length;
         }
       }),
       switchMap(evaluation => {


### PR DESCRIPTION
The Evaluation Remark field can now be expanded to a text area. Multiline remarks are displayed correctly in rendered feedback markdown.

Suggested by @nataschu 