### PR TITLE
Specify GitHub token in Classroom settings per assignment

### DIFF
--- a/frontend/src/app/assignment/model/assignment.ts
+++ b/frontend/src/app/assignment/model/assignment.ts
@@ -14,6 +14,7 @@ export default class Assignment {
   classroom?: {
     org?: string;
     prefix?: string;
+    token?: string;
     codeSearch?: boolean;
   };
 

--- a/frontend/src/app/assignment/modules/edit-assignment/classroom/classroom.component.html
+++ b/frontend/src/app/assignment/modules/edit-assignment/classroom/classroom.component.html
@@ -19,9 +19,30 @@
         <span class="input-group-text">-Student</span>
       </div>
     </div>
-    <small class="text-muted">
+    <div class="form-text small text-muted">
       Allows importing solutions from Classroom Submissions.
-    </small>
+    </div>
+  </div>
+  <div class="form-group">
+    <label for="tokenInput">GitHub Token</label>
+    <input
+      type="password" class="form-control" id="tokenInput" placeholder="ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      [(ngModel)]="assignment.classroom!.token" (change)="saveDraft()"
+    >
+    <div class="form-text small text-muted">
+      Required for importing solutions from GitHub Classroom.
+      You can generate a token in the
+      <a
+        href="https://github.com/settings/tokens/new?description={{encodeURIComponent(assignment.title)}}&scopes=repo"
+        target="_blank">
+        GitHub Settings
+      </a>.
+      Make sure your account has access to the
+      <b>{{ assignment.classroom!.org }}</b>
+      organisation and select the
+      <code>repo</code>
+      scope.
+    </div>
   </div>
   <div class="form-group">
     <label for="codeSearchCheck">Code Search</label>

--- a/frontend/src/app/assignment/modules/edit-assignment/classroom/classroom.component.ts
+++ b/frontend/src/app/assignment/modules/edit-assignment/classroom/classroom.component.ts
@@ -11,6 +11,8 @@ export class ClassroomComponent {
   assignment: Assignment;
   saveDraft: () => void;
 
+  encodeURIComponent = encodeURIComponent;
+
   constructor(
     context: AssignmentContext,
   ) {

--- a/services/apps/assignments/src/assignment/assignment.schema.ts
+++ b/services/apps/assignments/src/assignment/assignment.schema.ts
@@ -11,7 +11,6 @@ import {
   IsNumber,
   IsOptional,
   IsString,
-  IsUrl,
   ValidateNested,
 } from 'class-validator';
 import {Document} from 'mongoose';
@@ -78,7 +77,14 @@ export class ClassroomInfo {
   codeSearch?: boolean;
 }
 
-@Schema()
+@Schema({
+  toJSON: {
+    transform: (doc, ret) => {
+      delete ret.classroom?.token;
+      return ret;
+    },
+  },
+})
 export class Assignment {
   @Prop()
   @ApiProperty()

--- a/services/apps/assignments/src/assignment/assignment.schema.ts
+++ b/services/apps/assignments/src/assignment/assignment.schema.ts
@@ -68,6 +68,12 @@ export class ClassroomInfo {
   @Prop()
   @ApiPropertyOptional()
   @IsOptional()
+  @IsString()
+  token?: string;
+
+  @Prop()
+  @ApiPropertyOptional()
+  @IsOptional()
   @IsBoolean()
   codeSearch?: boolean;
 }

--- a/services/apps/assignments/src/classroom/classroom.controller.ts
+++ b/services/apps/assignments/src/classroom/classroom.controller.ts
@@ -1,4 +1,4 @@
-import {Controller, Headers, Param, Post, UploadedFiles, UseInterceptors} from '@nestjs/common';
+import {Controller, Param, Post, UploadedFiles, UseInterceptors} from '@nestjs/common';
 import {FilesInterceptor} from '@nestjs/platform-express';
 import {ApiCreatedResponse, ApiTags} from '@nestjs/swagger';
 import {AssignmentAuth} from '../assignment/assignment-auth.decorator';
@@ -21,9 +21,8 @@ export class ClassroomController {
   @ApiCreatedResponse({type: [ReadSolutionDto]})
   async importSolutions(
     @Param('assignment') assignment: string,
-    @Headers('Authorization') auth: string,
     @UploadedFiles() files?: Express.Multer.File[],
   ): Promise<ReadSolutionDto[]> {
-    return files ? this.classroomService.importFiles(assignment, files) : this.classroomService.importSolutions(assignment, auth);
+    return files ? this.classroomService.importFiles(assignment, files) : this.classroomService.importSolutions(assignment);
   }
 }

--- a/services/apps/assignments/src/classroom/classroom.scheduler.ts
+++ b/services/apps/assignments/src/classroom/classroom.scheduler.ts
@@ -2,7 +2,6 @@ import {Injectable} from '@nestjs/common';
 import {Cron, CronExpression} from '@nestjs/schedule';
 import {AssignmentDocument} from '../assignment/assignment.schema';
 import {AssignmentService} from '../assignment/assignment.service';
-import {environment} from '../environment';
 import {ClassroomService} from './classroom.service';
 
 @Injectable()
@@ -15,11 +14,6 @@ export class ClassroomScheduler {
 
   @Cron(CronExpression.EVERY_MINUTE)
   async autoImport() {
-    const {token} = environment.github;
-    if (!token) {
-      return;
-    }
-
     const startDate = new Date();
     startDate.setUTCSeconds(0, 0);
     const endDate = new Date(+startDate + 60 * 1000);
@@ -36,7 +30,7 @@ export class ClassroomScheduler {
     }
 
     const results = await Promise.all(assignments.map(async a => {
-      const ids = await this.classroomService.importSolutions2(a as AssignmentDocument, token);
+      const ids = await this.classroomService.importSolutions2(a as AssignmentDocument);
       return ids.length;
     }));
     const total = results.reduce((a, c) => a + c, 0);

--- a/services/apps/assignments/src/environment.ts
+++ b/services/apps/assignments/src/environment.ts
@@ -20,9 +20,6 @@ export const environment = {
   compiler: {
     apiUrl: process.env.COMPILER_API_URL || 'http://localhost:4567/api',
   },
-  github: {
-    token: process.env.GITHUB_TOKEN,
-  },
   nats: {
     servers: process.env.NATS_URL || 'nats://localhost:4222',
   },


### PR DESCRIPTION
This makes it possible for other organisations to use the scheduled import feature.
Manual import no longer requires being logged in or an account linked to GitHub.
The token is automatically redacted from all requests to not leak personal access from the creator to TAs.