### PR TITLE
Make error message for workflow downloads more precise

### DIFF
--- a/frontend/src/app/components/privacy/privacy.component.html
+++ b/frontend/src/app/components/privacy/privacy.component.html
@@ -44,6 +44,9 @@
       &rarr;
       <b>Edit Privacy Preferences</b> in the top navigation bar.
     </p>
+    <p>
+      Please note that <b>downloads may not work correctly</b> if you do not allow the use of local storage.
+    </p>
   </ng-container>
   <ng-container modal-footer>
     <button type="button" class="btn btn-secondary" (click)="modal.close()">

--- a/frontend/src/app/workflows/download-es/download-es.component.ts
+++ b/frontend/src/app/workflows/download-es/download-es.component.ts
@@ -59,7 +59,9 @@ export class DownloadESComponent implements OnInit {
   }
 
   download() {
-    if (this.yamlContent) {
+    if (!this.privacyService.allowLocalStorage) {
+      this.toastService.error('Could not download files', 'Please allow the use of local data storage in your Privacy Preferences.');
+    } else if (this.yamlContent) {
       this.workflowsService.downloadZip(this.yamlContent, this.exportOptions);
     } else {
       this.toastService.error('Download Files', 'Editor Content does not exist');


### PR DESCRIPTION
<!-- Please enter your detailed description below. -->

**Please not that this PR has not been tested very well due to the complex workspace setup. Please test before merging!**

If you disable local storage in the privacy settings, create a workflow using [fulibWorkflows](https://fulib.org/workflows) and try to download any type of output, it prints out an error into the little toast in the upper right corner. The error says: "Download Files - Editor Content does not exist". It doesn't matter what types of outputs are selected.

While this is not an error/a bug, the message displayed suggests that something went wrong and the content doesn't exist. Instead something like "Could not download files - Please allow the use of local data storage in your Privacy Preferences." should be displayed.

## Improvements

* Added a note to the Privacy Settings drop down menu.
* Made the error message more precise. #295

Closes #295