### PR TITLE
Use Refs in Project Schemas

### DIFF
--- a/services/apps/projects/src/container/container.controller.ts
+++ b/services/apps/projects/src/container/container.controller.ts
@@ -1,5 +1,5 @@
 import {Auth, AuthUser, UserToken} from '@app/keycloak-auth';
-import {NotFound} from '@mean-stream/nestx';
+import {NotFound, ObjectIdPipe} from '@mean-stream/nestx';
 import {
   Body,
   Controller,
@@ -14,6 +14,7 @@ import {
 } from '@nestjs/common';
 import {FileInterceptor} from '@nestjs/platform-express';
 import {ApiCreatedResponse, ApiNotFoundResponse, ApiOkResponse, ApiTags} from '@nestjs/swagger';
+import {Types} from 'mongoose';
 import {MemberAuth} from '../member/member-auth.decorator';
 import {ProjectService} from '../project/project.service';
 import {ContainerDto, CreateContainerDto} from './container.dto';
@@ -46,7 +47,7 @@ export class ContainerController {
   @ApiCreatedResponse({type: ContainerDto})
   @ApiNotFoundResponse({description: 'Project not found'})
   async create(
-    @Param('id') id: string,
+    @Param('id', ObjectIdPipe) id: Types.ObjectId,
     @Headers('Authorization') authorization: string,
     @AuthUser() user: UserToken,
   ): Promise<ContainerDto> {

--- a/services/apps/projects/src/member/member-auth.guard.ts
+++ b/services/apps/projects/src/member/member-auth.guard.ts
@@ -1,6 +1,8 @@
 import {UserToken} from '@app/keycloak-auth';
-import {CanActivate, ExecutionContext, Injectable} from '@nestjs/common';
+import {objectId} from '@mean-stream/nestx';
+import {BadRequestException, CanActivate, ExecutionContext, Injectable} from '@nestjs/common';
 import {Request} from 'express';
+import {Types} from 'mongoose';
 import {Observable} from 'rxjs';
 import {MemberService} from './member.service';
 
@@ -13,12 +15,12 @@ export class MemberAuthGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
     const req = context.switchToHttp().getRequest() as Request;
-    const id = req.params.project ?? req.params.id;
+    const id = objectId(req.params.project ?? req.params.id, error => new BadRequestException(error));
     const user = (req as any).user;
     return this.checkAuth(id, user);
   }
 
-  async checkAuth(id: string, user: UserToken): Promise<boolean> {
+  async checkAuth(id: Types.ObjectId, user: UserToken): Promise<boolean> {
     return !!await this.memberService.findOne(id, user.sub);
   }
 }

--- a/services/apps/projects/src/member/member.controller.ts
+++ b/services/apps/projects/src/member/member.controller.ts
@@ -1,7 +1,8 @@
 import {AuthUser, UserToken} from '@app/keycloak-auth';
-import {NotFound} from '@mean-stream/nestx';
+import {NotFound, ObjectIdPipe} from '@mean-stream/nestx';
 import {Body, ConflictException, Controller, Delete, Get, Param, Put} from '@nestjs/common';
 import {ApiConflictResponse, ApiOkResponse, ApiTags} from '@nestjs/swagger';
+import {Types} from 'mongoose';
 import {ProjectAuth} from '../project/project-auth.decorator';
 import {ProjectService} from '../project/project.service';
 import {MemberAuth} from './member-auth.decorator';
@@ -26,7 +27,7 @@ export class MemberController {
   @MemberAuth({forbiddenResponse})
   @ApiOkResponse({type: [Member]})
   async findAll(
-    @Param('project') projectId: string,
+    @Param('project', ObjectIdPipe) projectId: Types.ObjectId,
   ): Promise<Member[]> {
     return this.memberService.findAll({projectId});
   }
@@ -36,7 +37,7 @@ export class MemberController {
   @NotFound()
   @ApiOkResponse({type: Member})
   async findOne(
-    @Param('project') project: string,
+    @Param('project', ObjectIdPipe) project: Types.ObjectId,
     @Param('user') user: string,
   ): Promise<Member | null> {
     return this.memberService.findOne(project, user);
@@ -46,7 +47,7 @@ export class MemberController {
   @ProjectAuth({forbiddenResponse: forbiddenProjectResponse})
   @ApiOkResponse({type: Member})
   async update(
-    @Param('project') project: string,
+    @Param('project', ObjectIdPipe) project: Types.ObjectId,
     @Param('user') user: string,
     @Body() dto: UpdateMemberDto,
   ): Promise<Member> {
@@ -59,7 +60,7 @@ export class MemberController {
   @ApiOkResponse({type: Member})
   @ApiConflictResponse({description: removeOwnerResponse})
   async remove(
-    @Param('project') project: string,
+    @Param('project', ObjectIdPipe) project: Types.ObjectId,
     @Param('user') user: string,
     @AuthUser() token: UserToken,
   ): Promise<Member | null> {

--- a/services/apps/projects/src/member/member.module.ts
+++ b/services/apps/projects/src/member/member.module.ts
@@ -3,14 +3,14 @@ import {MongooseModule} from '@nestjs/mongoose';
 import {ProjectModule} from '../project/project.module';
 import {MemberAuthGuard} from './member-auth.guard';
 import {MemberController} from './member.controller';
-import {MemberSchema} from './member.schema';
+import {Member, MemberSchema} from './member.schema';
 import {MemberService} from './member.service';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       {
-        name: 'members',
+        name: Member.name,
         schema: MemberSchema,
       },
     ]),

--- a/services/apps/projects/src/member/member.schema.ts
+++ b/services/apps/projects/src/member/member.schema.ts
@@ -1,7 +1,7 @@
 import {Prop, Schema, SchemaFactory} from '@nestjs/mongoose';
 import {ApiProperty} from '@nestjs/swagger';
 import {IsMongoId} from 'class-validator';
-import {Document} from 'mongoose';
+import {Document, Types} from 'mongoose';
 
 @Schema({_id: false, id: false})
 export class Member {
@@ -15,7 +15,7 @@ export class Member {
   userId: string;
 }
 
-export type MemberDocument = Member & Document;
+export type MemberDocument = Member & Document<Types.ObjectId, any, Member>;
 
 export const MemberSchema = SchemaFactory.createForClass(Member)
   .index({projectId: 1, userId: 1}, {unique: true});

--- a/services/apps/projects/src/member/member.schema.ts
+++ b/services/apps/projects/src/member/member.schema.ts
@@ -6,9 +6,8 @@ import {Project} from '../project/project.schema';
 
 @Schema({_id: false, id: false})
 export class Member {
-  @Prop({index: 1})
   @Ref(Project.name)
-  projectId: string;
+  projectId: Types.ObjectId;
 
   @Prop()
   @ApiProperty()
@@ -18,4 +17,7 @@ export class Member {
 export type MemberDocument = Member & Document<Types.ObjectId, any, Member>;
 
 export const MemberSchema = SchemaFactory.createForClass(Member)
-  .index({projectId: 1, userId: 1}, {unique: true});
+  .index({projectId: 1})
+  .index({userId: 1})
+  .index({projectId: 1, userId: 1}, {unique: true})
+;

--- a/services/apps/projects/src/member/member.schema.ts
+++ b/services/apps/projects/src/member/member.schema.ts
@@ -1,13 +1,13 @@
+import {Ref} from '@mean-stream/nestx';
 import {Prop, Schema, SchemaFactory} from '@nestjs/mongoose';
 import {ApiProperty} from '@nestjs/swagger';
-import {IsMongoId} from 'class-validator';
 import {Document, Types} from 'mongoose';
+import {Project} from '../project/project.schema';
 
 @Schema({_id: false, id: false})
 export class Member {
   @Prop({index: 1})
-  @ApiProperty()
-  @IsMongoId()
+  @Ref(Project.name)
   projectId: string;
 
   @Prop()

--- a/services/apps/projects/src/member/member.service.ts
+++ b/services/apps/projects/src/member/member.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@nestjs/common';
 import {InjectModel} from '@nestjs/mongoose';
-import {FilterQuery, Model} from 'mongoose';
+import {FilterQuery, Model, Types} from 'mongoose';
 import {UpdateMemberDto} from './member.dto';
 import {Member, MemberDocument} from './member.schema';
 
@@ -15,18 +15,18 @@ export class MemberService {
     return this.model.find(where).exec();
   }
 
-  async findOne(projectId: string, userId: string): Promise<MemberDocument | null> {
+  async findOne(projectId: Types.ObjectId, userId: string): Promise<MemberDocument | null> {
     return this.model.findOne({projectId, userId}).exec();
   }
 
-  async update(projectId: string, userId: string, dto: UpdateMemberDto): Promise<Member> {
+  async update(projectId: Types.ObjectId, userId: string, dto: UpdateMemberDto): Promise<Member> {
     return this.model.findOneAndReplace({projectId, userId}, {...dto, projectId, userId}, {
       new: true,
       upsert: true,
     }).exec();
   }
 
-  async remove(projectId: string, userId: string): Promise<MemberDocument | null> {
+  async remove(projectId: Types.ObjectId, userId: string): Promise<MemberDocument | null> {
     return this.model.findOneAndDelete({projectId, userId}).exec();
   }
 

--- a/services/apps/projects/src/member/member.service.ts
+++ b/services/apps/projects/src/member/member.service.ts
@@ -7,7 +7,7 @@ import {Member, MemberDocument} from './member.schema';
 @Injectable()
 export class MemberService {
   constructor(
-    @InjectModel('members') private model: Model<Member>,
+    @InjectModel(Member.name) private model: Model<Member>,
   ) {
   }
 

--- a/services/apps/projects/src/project/project-auth.guard.ts
+++ b/services/apps/projects/src/project/project-auth.guard.ts
@@ -1,7 +1,8 @@
 import {UserToken} from '@app/keycloak-auth';
-import {notFound} from '@mean-stream/nestx';
-import {CanActivate, ExecutionContext, Injectable} from '@nestjs/common';
+import {notFound, objectId} from '@mean-stream/nestx';
+import {BadRequestException, CanActivate, ExecutionContext, Injectable} from '@nestjs/common';
 import {Request} from 'express';
+import {Types} from 'mongoose';
 import {Observable} from 'rxjs';
 import {ProjectService} from './project.service';
 
@@ -14,12 +15,12 @@ export class ProjectAuthGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
     const req = context.switchToHttp().getRequest() as Request;
-    const id = req.params.project ?? req.params.id;
+    const id = objectId(req.params.project ?? req.params.id, error => new BadRequestException(error));
     const user = (req as any).user;
     return this.checkAuth(id, user);
   }
 
-  async checkAuth(id: string, user: UserToken): Promise<boolean> {
+  async checkAuth(id: Types.ObjectId, user: UserToken): Promise<boolean> {
     const project = await this.projectService.findOne(id) ?? notFound(id);
     return this.projectService.isAuthorized(project, user);
   }

--- a/services/apps/projects/src/project/project.controller.ts
+++ b/services/apps/projects/src/project/project.controller.ts
@@ -1,7 +1,8 @@
 import {Auth, AuthUser, UserToken} from '@app/keycloak-auth';
-import {NotFound} from '@mean-stream/nestx';
+import {NotFound, ObjectIdPipe} from '@mean-stream/nestx';
 import {Body, Controller, Delete, Get, Param, Patch, Post} from '@nestjs/common';
 import {ApiCreatedResponse, ApiOkResponse, ApiTags} from '@nestjs/swagger';
+import {Types} from 'mongoose';
 import {MemberAuth} from '../member/member-auth.decorator';
 import {MemberService} from '../member/member.service';
 import {ProjectAuth} from './project-auth.decorator';
@@ -48,7 +49,7 @@ export class ProjectController {
   @NotFound()
   @ApiOkResponse({type: Project})
   async findOne(
-    @Param('id') id: string,
+    @Param('id', ObjectIdPipe) id: Types.ObjectId,
   ): Promise<Project | null> {
     return this.projectService.findOne(id);
   }
@@ -58,13 +59,13 @@ export class ProjectController {
   @NotFound()
   @ApiOkResponse({type: Project})
   async update(
-    @Param('id') id: string,
+    @Param('id', ObjectIdPipe) id: Types.ObjectId,
     @Body() dto: UpdateProjectDto,
   ): Promise<Project | null> {
     const project = await this.projectService.update(id, dto);
     if (project && dto.userId) {
       // when changing owner, create a member
-      await this.memberService.update(id, dto.userId, {});
+      await this.memberService.update(id.toString(), dto.userId, {});
     }
     return project;
   }
@@ -74,7 +75,7 @@ export class ProjectController {
   @NotFound()
   @ApiOkResponse({type: Project})
   async remove(
-    @Param('id') id: string,
+    @Param('id', ObjectIdPipe) id: Types.ObjectId,
   ): Promise<Project | null> {
     await this.memberService.removeAll({projectId: id});
     return this.projectService.remove(id);

--- a/services/apps/projects/src/project/project.controller.ts
+++ b/services/apps/projects/src/project/project.controller.ts
@@ -30,7 +30,7 @@ export class ProjectController {
     @AuthUser() user: UserToken,
   ): Promise<Project> {
     const project = await this.projectService.create(dto, user.sub);
-    project && await this.memberService.update(project.id, user.sub, {});
+    project && await this.memberService.update(project._id, user.sub, {});
     return project;
   }
 
@@ -65,7 +65,7 @@ export class ProjectController {
     const project = await this.projectService.update(id, dto);
     if (project && dto.userId) {
       // when changing owner, create a member
-      await this.memberService.update(id.toString(), dto.userId, {});
+      await this.memberService.update(id, dto.userId, {});
     }
     return project;
   }

--- a/services/apps/projects/src/project/project.module.ts
+++ b/services/apps/projects/src/project/project.module.ts
@@ -3,14 +3,14 @@ import {MongooseModule} from '@nestjs/mongoose';
 import {MemberModule} from '../member/member.module';
 import {ProjectAuthGuard} from './project-auth.guard';
 import {ProjectController} from './project.controller';
-import {ProjectSchema} from './project.schema';
+import {Project, ProjectSchema} from './project.schema';
 import {ProjectService} from './project.service';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       {
-        name: 'projects',
+        name: Project.name,
         schema: ProjectSchema,
       },
     ]),

--- a/services/apps/projects/src/project/project.schema.ts
+++ b/services/apps/projects/src/project/project.schema.ts
@@ -5,6 +5,7 @@ import {Document, Types} from 'mongoose';
 
 @Schema()
 export class Project {
+  @ApiProperty()
   _id!: Types.ObjectId;
 
   @Prop({index: 1})
@@ -47,7 +48,7 @@ export class Project {
   created: Date;
 }
 
-export type ProjectDocument = Project & Document;
+export type ProjectDocument = Project & Document<Types.ObjectId, any, Project>;
 
 export const ProjectSchema = SchemaFactory.createForClass(Project)
   .set('toJSON', {virtuals: true})

--- a/services/apps/projects/src/project/project.service.ts
+++ b/services/apps/projects/src/project/project.service.ts
@@ -17,7 +17,7 @@ const bindPrefix = path.resolve(environment.docker.bindPrefix);
 @Injectable()
 export class ProjectService {
   constructor(
-    @InjectModel('projects') private model: Model<Project>,
+    @InjectModel(Project.name) private model: Model<Project>,
   ) {
   }
 

--- a/services/apps/projects/src/project/project.service.ts
+++ b/services/apps/projects/src/project/project.service.ts
@@ -2,7 +2,7 @@ import {UserToken} from '@app/keycloak-auth';
 import {Injectable} from '@nestjs/common';
 import {InjectModel} from '@nestjs/mongoose';
 import * as fs from 'fs';
-import {FilterQuery, Model} from 'mongoose';
+import {FilterQuery, Model, Types} from 'mongoose';
 import * as path from 'path';
 import {environment} from '../environment';
 import {CreateProjectDto, UpdateProjectDto} from './project.dto';
@@ -33,18 +33,18 @@ export class ProjectService {
     return this.model.find(where).sort('+name').exec();
   }
 
-  async findOne(id: string): Promise<ProjectDocument | null> {
+  async findOne(id: Types.ObjectId): Promise<ProjectDocument | null> {
     return this.model.findById(id).exec();
   }
 
-  async update(id: string, dto: UpdateProjectDto): Promise<Project | null> {
+  async update(id: Types.ObjectId, dto: UpdateProjectDto): Promise<Project | null> {
     return this.model.findByIdAndUpdate(id, dto, {new: true}).exec();
   }
 
-  async remove(id: string): Promise<ProjectDocument | null> {
+  async remove(id: Types.ObjectId): Promise<ProjectDocument | null> {
     const project = await this.model.findByIdAndDelete(id).exec();
     if (project) {
-      this.removeStorage(id);
+      this.removeStorage(id.toString());
     }
     return project;
   }

--- a/services/package.json
+++ b/services/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@elastic/elasticsearch": "~7.13.0",
-    "@mean-stream/nestx": "^0.4.0",
+    "@mean-stream/nestx": "^0.5.0",
     "@nestjs/axios": "^2.0.0",
     "@nestjs/common": "^9.4.0",
     "@nestjs/core": "^9.4.0",
@@ -42,7 +42,7 @@
     "bson-objectid": "^2.0.4",
     "chownr": "^2.0.0",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.13.2",
+    "class-validator": "^0.14.0",
     "dockerode": "^3.3.5",
     "express": "^4.18.2",
     "glob-to-regexp": "^0.4.1",

--- a/services/pnpm-lock.yaml
+++ b/services/pnpm-lock.yaml
@@ -9,14 +9,14 @@ dependencies:
     specifier: ~7.13.0
     version: 7.13.0
   '@mean-stream/nestx':
-    specifier: ^0.4.0
-    version: 0.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/event-emitter@1.4.1)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/swagger@6.3.0)(@nestjs/websockets@9.4.0)(nats@2.13.1)(reflect-metadata@0.1.13)(rxjs@7.8.0)(tslib@2.5.0)
+    specifier: ^0.5.0
+    version: 0.5.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/event-emitter@1.4.1)(@nestjs/microservices@9.4.0)(@nestjs/mongoose@9.2.2)(@nestjs/platform-express@9.4.0)(@nestjs/swagger@6.3.0)(@nestjs/websockets@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(mongoose@7.0.3)(nats@2.13.1)(reflect-metadata@0.1.13)(rxjs@7.8.0)(tslib@2.5.0)
   '@nestjs/axios':
     specifier: ^2.0.0
     version: 2.0.0(@nestjs/common@9.4.0)(axios@1.3.5)(reflect-metadata@0.1.13)(rxjs@7.8.0)
   '@nestjs/common':
     specifier: ^9.4.0
-    version: 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+    version: 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
   '@nestjs/core':
     specifier: ^9.4.0
     version: 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
@@ -46,7 +46,7 @@ dependencies:
     version: 2.2.1(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(reflect-metadata@0.1.13)
   '@nestjs/swagger':
     specifier: ^6.3.0
-    version: 6.3.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)
+    version: 6.3.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
   '@nestjs/websockets':
     specifier: ^9.4.0
     version: 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
@@ -69,8 +69,8 @@ dependencies:
     specifier: ^0.5.1
     version: 0.5.1
   class-validator:
-    specifier: ^0.13.2
-    version: 0.13.2
+    specifier: ^0.14.0
+    version: 0.14.0
   dockerode:
     specifier: ^3.3.5
     version: 3.3.5
@@ -961,16 +961,20 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
-  /@mean-stream/nestx@0.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/event-emitter@1.4.1)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/swagger@6.3.0)(@nestjs/websockets@9.4.0)(nats@2.13.1)(reflect-metadata@0.1.13)(rxjs@7.8.0)(tslib@2.5.0):
-    resolution: {integrity: sha512-XqzgbLklPLRDfzRqAEGpOFvjaVchioBsVVQfE/l4AaoBcngxaMRyMvHkn6nLcMwfsMWn4JQK7Gl53L6XLaC4Uw==}
+  /@mean-stream/nestx@0.5.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/event-emitter@1.4.1)(@nestjs/microservices@9.4.0)(@nestjs/mongoose@9.2.2)(@nestjs/platform-express@9.4.0)(@nestjs/swagger@6.3.0)(@nestjs/websockets@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(mongoose@7.0.3)(nats@2.13.1)(reflect-metadata@0.1.13)(rxjs@7.8.0)(tslib@2.5.0):
+    resolution: {integrity: sha512-DWW/kme8mqsDRri4arObOXLLGwIIC0Ju5p0dXnEJMkPyk9GMF9yGy1TU87TQR/DvT0t8RWMRJDJLwxcPgkIjnQ==}
     peerDependencies:
       '@nestjs/common': ^9.0.0
       '@nestjs/core': ^9.0.0
       '@nestjs/event-emitter': ^1.0.0
       '@nestjs/microservices': ^9.0.0
+      '@nestjs/mongoose': ^9.0.0
       '@nestjs/platform-express': ^9.0.0
       '@nestjs/swagger': ^6.0.0
       '@nestjs/websockets': ^9.0.0
+      class-transformer: ^0.5.0
+      class-validator: ^0.14.0
+      mongoose: ^7.0.0
       nats: ^2.13.0
       reflect-metadata: ^0.1.0
       rxjs: ^7.0.0
@@ -980,22 +984,30 @@ packages:
         optional: true
       '@nestjs/microservices':
         optional: true
+      '@nestjs/mongoose':
+        optional: true
       '@nestjs/platform-express':
         optional: true
       '@nestjs/swagger':
         optional: true
       '@nestjs/websockets':
         optional: true
+      mongoose:
+        optional: true
       nats:
         optional: true
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/event-emitter': 1.4.1(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(reflect-metadata@0.1.13)
       '@nestjs/microservices': 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/websockets@9.4.0)(nats@2.13.1)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/mongoose': 9.2.2(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(mongoose@7.0.3)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/platform-express': 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)
-      '@nestjs/swagger': 6.3.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)
+      '@nestjs/swagger': 6.3.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
       '@nestjs/websockets': 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      class-transformer: 0.5.1
+      class-validator: 0.14.0
+      mongoose: 7.0.3
       nats: 2.13.1
       reflect-metadata: 0.1.13
       rxjs: 7.8.0
@@ -1010,7 +1022,7 @@ packages:
       reflect-metadata: ^0.1.12
       rxjs: ^6.0.0 || ^7.0.0
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       axios: 1.3.5
       reflect-metadata: 0.1.13
       rxjs: 7.8.0
@@ -1050,7 +1062,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nestjs/common@9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0):
+  /@nestjs/common@9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0):
     resolution: {integrity: sha512-RUcVAQsEF4WPrmzFXEOUfZnPwrLTe1UVlzXTlSyfqfqbdWDPKDGlIPVelBLfc5/+RRUQ0I5iE4+CQvpCmkqldw==}
     peerDependencies:
       cache-manager: <=5
@@ -1067,7 +1079,7 @@ packages:
         optional: true
     dependencies:
       class-transformer: 0.5.1
-      class-validator: 0.13.2
+      class-validator: 0.14.0
       iterare: 1.2.1
       reflect-metadata: 0.1.13
       rxjs: 7.8.0
@@ -1092,7 +1104,7 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/microservices': 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/websockets@9.4.0)(nats@2.13.1)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/platform-express': 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)
       '@nestjs/websockets': 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
@@ -1115,7 +1127,7 @@ packages:
       rxjs: ^7.2.0
     dependencies:
       '@elastic/elasticsearch': 7.13.0
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       rxjs: 7.8.0
     dev: false
 
@@ -1126,7 +1138,7 @@ packages:
       '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0
       reflect-metadata: ^0.1.12
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       eventemitter2: 6.4.9
       reflect-metadata: 0.1.13
@@ -1137,12 +1149,12 @@ packages:
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@types/jsonwebtoken': 9.0.1
       jsonwebtoken: 9.0.0
     dev: false
 
-  /@nestjs/mapped-types@1.2.2(@nestjs/common@9.4.0)(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13):
+  /@nestjs/mapped-types@1.2.2(@nestjs/common@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-3dHxLXs3M0GPiriAcCFFJQHoDFUuzTD5w6JDhE7TyfT89YKpe6tcCCIqOZWdXmt9AZjjK30RkHRSFF+QEnWFQg==}
     peerDependencies:
       '@nestjs/common': ^7.0.8 || ^8.0.0 || ^9.0.0
@@ -1155,9 +1167,9 @@ packages:
       class-validator:
         optional: true
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       class-transformer: 0.5.1
-      class-validator: 0.13.2
+      class-validator: 0.14.0
       reflect-metadata: 0.1.13
     dev: false
 
@@ -1197,7 +1209,7 @@ packages:
       nats:
         optional: true
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/websockets': 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       iterare: 1.2.1
@@ -1215,7 +1227,7 @@ packages:
       reflect-metadata: ^0.1.12
       rxjs: ^7.0.0
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       mongoose: 7.0.3
       reflect-metadata: 0.1.13
@@ -1228,7 +1240,7 @@ packages:
       '@nestjs/common': ^8.0.0 || ^9.0.0
       passport: ^0.4.0 || ^0.5.0 || ^0.6.0
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       passport: 0.6.0
     dev: false
 
@@ -1238,7 +1250,7 @@ packages:
       '@nestjs/common': ^9.0.0
       '@nestjs/core': ^9.0.0
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       body-parser: 1.20.2
       cors: 2.8.5
@@ -1255,7 +1267,7 @@ packages:
       '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0
       reflect-metadata: ^0.1.12
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       cron: 2.3.0
       reflect-metadata: 0.1.13
@@ -1276,7 +1288,7 @@ packages:
       - chokidar
     dev: true
 
-  /@nestjs/swagger@6.3.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13):
+  /@nestjs/swagger@6.3.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-Gnig189oa1tD+h0BYIfUwhp/wvvmTn6iO3csR2E4rQrDTgCxSxZDlNdfZo3AC+Rmf8u0KX4ZAX1RZN1qXTtC7A==}
     peerDependencies:
       '@fastify/static': ^6.0.0
@@ -1293,11 +1305,11 @@ packages:
       class-validator:
         optional: true
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
-      '@nestjs/mapped-types': 1.2.2(@nestjs/common@9.4.0)(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)
+      '@nestjs/mapped-types': 1.2.2(@nestjs/common@9.4.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
       class-transformer: 0.5.1
-      class-validator: 0.13.2
+      class-validator: 0.14.0
       js-yaml: 4.1.0
       lodash: 4.17.21
       path-to-regexp: 3.2.0
@@ -1318,7 +1330,7 @@ packages:
       '@nestjs/platform-express':
         optional: true
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/microservices': 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)(@nestjs/websockets@9.4.0)(nats@2.13.1)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/platform-express': 9.4.0(@nestjs/common@9.4.0)(@nestjs/core@9.4.0)
@@ -1337,7 +1349,7 @@ packages:
       '@nestjs/platform-socket.io':
         optional: true
     dependencies:
-      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.13.2)(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/common': 9.4.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       '@nestjs/core': 9.4.0(@nestjs/common@9.4.0)(@nestjs/microservices@9.4.0)(@nestjs/platform-express@9.4.0)(@nestjs/websockets@9.4.0)(reflect-metadata@0.1.13)(rxjs@7.8.0)
       iterare: 1.2.1
       object-hash: 3.0.0
@@ -1666,6 +1678,9 @@ packages:
     dependencies:
       '@types/node': 18.15.11
     dev: true
+
+  /@types/validator@13.7.15:
+    resolution: {integrity: sha512-yeinDVQunb03AEP8luErFcyf/7Lf7AzKCD0NXfgVoGCCQDNpZET8Jgq74oBgqKld3hafLbfzt/3inUdQvaFeXQ==}
 
   /@types/webidl-conversions@7.0.0:
     resolution: {integrity: sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==}
@@ -2448,9 +2463,10 @@ packages:
   /class-transformer@0.5.1:
     resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
 
-  /class-validator@0.13.2:
-    resolution: {integrity: sha512-yBUcQy07FPlGzUjoLuUfIOXzgynnQPPruyK1Ge2B74k9ROwnle1E+NxLWnUv5OLU8hA/qL5leAE9XnXq3byaBw==}
+  /class-validator@0.14.0:
+    resolution: {integrity: sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==}
     dependencies:
+      '@types/validator': 13.7.15
       libphonenumber-js: 1.10.26
       validator: 13.9.0
 


### PR DESCRIPTION
This is just a minor refactor that uses ObjectIds instead of strings in the Projects Service and Members database.
All existing Member documents will be migrated automatically.