### PR TITLE
IntelliJ Plugin Support

### DIFF
--- a/frontend/src/app/assignment/model/config.ts
+++ b/frontend/src/app/assignment/model/config.ts
@@ -11,6 +11,8 @@ export const IDEs = {
   'pycharm': 'PyCharm',
 } as const;
 
+export type IDE = keyof typeof IDEs;
+
 export class Config {
   @Presentation({
     description: 'Your full name for use in assignments, solutions, comments and evaluations.',
@@ -32,7 +34,7 @@ export class Config {
     optionLabels: IDEs,
   })
   @IsIn(Object.keys(IDEs))
-  ide: keyof typeof IDEs = 'vscode';
+  ide: IDE = 'vscode';
 
   @Presentation({
     label: 'Git Clone Protocol',

--- a/frontend/src/app/assignment/model/config.ts
+++ b/frontend/src/app/assignment/model/config.ts
@@ -2,6 +2,15 @@ import {IsBoolean, IsEmail, IsIn, IsNotEmpty, IsString} from "class-validator";
 import {Presentation} from "@mean-stream/ngbx";
 import {Transform} from "class-transformer";
 
+export const IDEs = {
+  vscode: 'VSCode',
+  'code-oss': 'Code - OSS',
+  vscodium: 'VSCodium',
+  idea: 'IntelliJ IDEA',
+  'web-storm': 'WebStorm',
+  'pycharm': 'PyCharm',
+} as const;
+
 export class Config {
   @Presentation({
     description: 'Your full name for use in assignments, solutions, comments and evaluations.',
@@ -20,14 +29,10 @@ export class Config {
   @Presentation({
     label: 'IDE',
     description: 'Your preferred IDE for cloning repositories.',
-    optionLabels: {
-      vscode: 'VSCode',
-      'code-oss': 'Code - OSS',
-      vscodium: 'VSCodium',
-    },
+    optionLabels: IDEs,
   })
-  @IsIn(['vscode', 'code-oss', 'vscodium'])
-  ide: 'vscode' | 'code-oss' | 'vscodium' = 'vscode';
+  @IsIn(Object.keys(IDEs))
+  ide: keyof typeof IDEs = 'vscode';
 
   @Presentation({
     label: 'Git Clone Protocol',

--- a/frontend/src/app/assignment/modules/assignment/search/search.component.html
+++ b/frontend/src/app/assignment/modules/assignment/search/search.component.html
@@ -69,7 +69,12 @@
         <ul class="list-group">
           @for (snippet of result.snippets;track snippet) {
             <li class="list-group-item">
-              <app-snippet [snippet]="snippet" [expanded]="results.length < 10 && result.snippets.length < 10"></app-snippet>
+              <app-snippet
+                [assignment]="assignment"
+                [solution]="solutions[result.solution]"
+                [snippet]="snippet"
+                [expanded]="results.length < 10 && result.snippets.length < 10"
+              ></app-snippet>
             </li>
           }
         </ul>

--- a/frontend/src/app/assignment/modules/assignment/submit.service.ts
+++ b/frontend/src/app/assignment/modules/assignment/submit.service.ts
@@ -171,7 +171,7 @@ export class SubmitService {
 <details>
 <summary>View Evaluations in VSCode</summary>
 
-Download the [fulibFeedback Extension](https://marketplace.visualstudio.com/items?itemName=fulib.fulibFeedback) \
+Download the [fulibFeedback Extension](https://github.com/fujaba/fulibFeedback) \
 and copy this to \`.vscode/settings.json\`:
 
 \`\`\`json

--- a/frontend/src/app/assignment/modules/shared/assignment-actions/assignment-actions.component.html
+++ b/frontend/src/app/assignment/modules/shared/assignment-actions/assignment-actions.component.html
@@ -14,7 +14,7 @@
     </a>
     <a ngbDropdownItem class="bi-magic"
        ngbTooltip="Automatically configure fulibFeedback for this assigmnent in your IDE"
-       [href]="ide + '://fulib.fulibfeedback/configure?api_server=' + encodedApiServer + '&assignment=' + assignment._id + '&token=' + assignment['token'] | safeUrl">
+       [href]="ide|fulibFeedbackLink:assignment._id:undefined:assignment['token'] | safeUrl">
       Configure fulibFeedback
     </a>
     <div class="dropdown-divider"></div>

--- a/frontend/src/app/assignment/modules/shared/assignment-actions/assignment-actions.component.ts
+++ b/frontend/src/app/assignment/modules/shared/assignment-actions/assignment-actions.component.ts
@@ -3,7 +3,7 @@ import {ToastService} from '@mean-stream/ngbx';
 import {ReadAssignmentDto} from '../../../model/assignment';
 import {AssignmentService} from '../../../services/assignment.service';
 import {ConfigService} from "../../../services/config.service";
-import {environment} from "../../../../../environments/environment";
+import {IDE} from "../../../model/config";
 
 @Component({
   selector: 'app-assignment-actions',
@@ -14,8 +14,7 @@ export class AssignmentActionsComponent {
   @Input() assignment: ReadAssignmentDto;
   @Output() removed = new EventEmitter<void>();
 
-  readonly ide: string;
-  readonly encodedApiServer = encodeURIComponent(new URL(environment.assignmentsApiUrl, globalThis.location?.origin).origin);
+  readonly ide: IDE;
 
   constructor(
     private assignmentService: AssignmentService,

--- a/frontend/src/app/assignment/modules/shared/pipes/clone-link.pipe.ts
+++ b/frontend/src/app/assignment/modules/shared/pipes/clone-link.pipe.ts
@@ -22,6 +22,16 @@ export class CloneLinkPipe implements PipeTransform {
         ref = `&ref=assignments/${assignment._id}`;
         break;
     }
-    return `${ide}://vscode.git/clone?url=${clonePrefix[cloneProtocol]}${org}%2F${prefix}-${user}${cloneSuffix[cloneProtocol]}${ref}`;
+    const cloneUrl = `${clonePrefix[cloneProtocol]}${org}%2F${prefix}-${user}${cloneSuffix[cloneProtocol]}`;
+    switch (ide) {
+      case 'vscode':
+      case 'code-oss':
+      case 'vscodium':
+        return `${ide}://vscode.git/clone?url=${cloneUrl}${ref}`;
+      case 'idea':
+      case 'web-storm':
+      case 'pycharm':
+        return `jetbrains://${ide}/checkout/git?checkout.repo=${cloneUrl}&idea.required.plugins.id=Git4Idea${ref}`;
+    }
   }
 }

--- a/frontend/src/app/assignment/modules/shared/pipes/fulibfeedback-link.pipe.ts
+++ b/frontend/src/app/assignment/modules/shared/pipes/fulibfeedback-link.pipe.ts
@@ -1,0 +1,31 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {environment} from "../../../../../environments/environment";
+import {HttpParams} from "@angular/common/http";
+import {IDE} from "../../../model/config";
+
+
+@Pipe({
+  name: 'fulibFeedbackLink',
+})
+export class FulibFeedbackLinkPipe implements PipeTransform {
+  transform(ide: IDE, assignment: string, solution: string | undefined, token: string): string {
+    const qs = new HttpParams({
+      fromObject: {
+        api_server: new URL(environment.assignmentsApiUrl, globalThis.location?.origin).origin,
+        assignment,
+        ...(solution ? {solution} : {}),
+        token,
+      },
+    }).toString();
+    switch (ide) {
+      case 'vscode':
+      case 'code-oss':
+      case 'vscodium':
+        return `${ide}://fulib.fulibFeedback/configure?${qs}`;
+      case 'idea':
+      case 'web-storm':
+      case 'pycharm':
+        return `jetbrains://${ide}/fulibFeedback/configure?${qs}`;
+    }
+  }
+}

--- a/frontend/src/app/assignment/modules/shared/pipes/navigate-link.pipe.ts
+++ b/frontend/src/app/assignment/modules/shared/pipes/navigate-link.pipe.ts
@@ -1,0 +1,26 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {IDE} from "../../../model/config";
+import {ReadAssignmentDto} from "../../../model/assignment";
+import Solution from "../../../model/solution";
+import {Snippet} from "../../../model/evaluation";
+
+
+@Pipe({
+  name: 'navigateLink',
+})
+export class NavigateLinkPipe implements PipeTransform {
+  transform(ide: IDE, assignment: ReadAssignmentDto | undefined, solution: Solution | undefined, snippet: Snippet): string {
+    const path = encodeURIComponent(snippet.file);
+    switch (ide) {
+      case 'vscode':
+      case 'vscodium':
+      case 'code-oss':
+        return `${ide}://fulib.fulibfeedback/open?file=${path}&line=${snippet.from.line}&endline=${snippet.to.line}`;
+      case 'idea':
+      case 'pycharm':
+      case 'web-storm':
+        const project = assignment?.classroom?.prefix + '-' + solution?.author?.github;
+        return `jetbrains://${ide}/navigate/reference?project=${project}&path=${path}:${snippet.from.line}:${snippet.from.character}`;
+    }
+  }
+}

--- a/frontend/src/app/assignment/modules/shared/shared.module.ts
+++ b/frontend/src/app/assignment/modules/shared/shared.module.ts
@@ -20,6 +20,7 @@ import {UserModule} from "../../../user/user.module";
 import {InitialsPipe} from "./pipes/initials.pipe";
 import {AssigneeDropdownComponent} from './assignee-dropdown/assignee-dropdown.component';
 import {AssigneeColorPipe} from "./pipes/assignee-color.pipe";
+import {FulibFeedbackLinkPipe} from "./pipes/fulibfeedback-link.pipe";
 
 @NgModule({
   imports: [
@@ -48,6 +49,7 @@ import {AssigneeColorPipe} from "./pipes/assignee-color.pipe";
     InitialsPipe,
     AssigneeDropdownComponent,
     AssigneeColorPipe,
+    FulibFeedbackLinkPipe,
   ],
   exports: [
     AssignmentInfoComponent,
@@ -65,6 +67,7 @@ import {AssigneeColorPipe} from "./pipes/assignee-color.pipe";
     InitialsPipe,
     AssigneeDropdownComponent,
     AssigneeColorPipe,
+    FulibFeedbackLinkPipe,
   ],
 })
 export class AssignmentSharedModule {

--- a/frontend/src/app/assignment/modules/shared/shared.module.ts
+++ b/frontend/src/app/assignment/modules/shared/shared.module.ts
@@ -21,6 +21,7 @@ import {InitialsPipe} from "./pipes/initials.pipe";
 import {AssigneeDropdownComponent} from './assignee-dropdown/assignee-dropdown.component';
 import {AssigneeColorPipe} from "./pipes/assignee-color.pipe";
 import {FulibFeedbackLinkPipe} from "./pipes/fulibfeedback-link.pipe";
+import {NavigateLinkPipe} from "./pipes/navigate-link.pipe";
 
 @NgModule({
   imports: [
@@ -50,6 +51,7 @@ import {FulibFeedbackLinkPipe} from "./pipes/fulibfeedback-link.pipe";
     AssigneeDropdownComponent,
     AssigneeColorPipe,
     FulibFeedbackLinkPipe,
+    NavigateLinkPipe,
   ],
   exports: [
     AssignmentInfoComponent,
@@ -68,6 +70,7 @@ import {FulibFeedbackLinkPipe} from "./pipes/fulibfeedback-link.pipe";
     AssigneeDropdownComponent,
     AssigneeColorPipe,
     FulibFeedbackLinkPipe,
+    NavigateLinkPipe,
   ],
 })
 export class AssignmentSharedModule {

--- a/frontend/src/app/assignment/modules/shared/snippet/snippet.component.html
+++ b/frontend/src/app/assignment/modules/shared/snippet/snippet.component.html
@@ -8,7 +8,7 @@
       <i class="bi bi-check-circle link-success" ngbTooltip="Confirm Suggestion" (click)="confirmed.next(snippet)"></i>
     }
     &nbsp;
-    <a class="bi bi-code-square" ngbTooltip="Open in Editor" [href]="openUrl | safeUrl"></a>
+    <a class="bi bi-code-square" ngbTooltip="Open in Editor" [href]="ide|navigateLink:assignment:solution:snippet | safeUrl"></a>
   </summary>
   <div class="markdown overflow-auto" style="max-height: 300px">
     <pre><code #code class="hljs language-{{fileType}}" [lang]="fileType" (mouseup)="onSelectionChange()">{{snippet.context ?? snippet.code}}</code></pre>

--- a/frontend/src/app/assignment/modules/shared/snippet/snippet.component.ts
+++ b/frontend/src/app/assignment/modules/shared/snippet/snippet.component.ts
@@ -2,6 +2,8 @@ import {Component, ElementRef, EventEmitter, Input, OnChanges, Output, SimpleCha
 import hljs from 'highlight.js/lib/core';
 import {Snippet} from '../../../model/evaluation';
 import {ConfigService} from "../../../services/config.service";
+import Solution from "../../../model/solution";
+import Assignment, {ReadAssignmentDto} from "../../../model/assignment";
 
 @Component({
   selector: 'app-snippet',
@@ -11,7 +13,9 @@ import {ConfigService} from "../../../services/config.service";
 export class SnippetComponent implements OnChanges {
   @ViewChild('code') code: ElementRef<HTMLElement>;
 
-  @Input() snippet: Snippet;
+  @Input({required: true}) assignment?: ReadAssignmentDto;
+  @Input({required: true}) solution?: Solution;
+  @Input({required: true}) snippet: Snippet;
   @Input() expanded = true;
   @Input() wildcard?: string;
   @Output() updated = new EventEmitter<Snippet>();
@@ -31,6 +35,10 @@ export class SnippetComponent implements OnChanges {
       const snippet = changes.snippet.currentValue;
       this.fileType = snippet.file.substring(snippet.file.lastIndexOf('.') + 1);
       this.contextLines = snippet.context ? 2 : 0;
+      // TODO `jetbrains://${ide}/navigate/reference?project=${project}&path=${filePath}:${lineIndex}:${columnIndex}`;
+      //      - project is the name of the repo, e.g. "stc-23-language-Clashsoft"
+      //      - filePath is the path to the file, e.g. "src/main/java/org/example/MyClass.java"
+      //      - lineIndex and columnIndex are 0-based
       this.openUrl = `${this.configService.get('ide')}://fulib.fulibfeedback/open?file=${encodeURIComponent(snippet.file)}&line=${snippet.from.line}&endline=${snippet.to.line}`;
     }
     if (changes.expanded) {

--- a/frontend/src/app/assignment/modules/shared/snippet/snippet.component.ts
+++ b/frontend/src/app/assignment/modules/shared/snippet/snippet.component.ts
@@ -3,7 +3,8 @@ import hljs from 'highlight.js/lib/core';
 import {Snippet} from '../../../model/evaluation';
 import {ConfigService} from "../../../services/config.service";
 import Solution from "../../../model/solution";
-import Assignment, {ReadAssignmentDto} from "../../../model/assignment";
+import {ReadAssignmentDto} from "../../../model/assignment";
+import {IDE} from "../../../model/config";
 
 @Component({
   selector: 'app-snippet',
@@ -23,11 +24,12 @@ export class SnippetComponent implements OnChanges {
 
   fileType?: string;
   contextLines = 0;
-  openUrl = '';
+  ide: IDE;
 
   constructor(
-    private readonly configService: ConfigService,
+    configService: ConfigService,
   ) {
+    this.ide = configService.get('ide');
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -35,11 +37,6 @@ export class SnippetComponent implements OnChanges {
       const snippet = changes.snippet.currentValue;
       this.fileType = snippet.file.substring(snippet.file.lastIndexOf('.') + 1);
       this.contextLines = snippet.context ? 2 : 0;
-      // TODO `jetbrains://${ide}/navigate/reference?project=${project}&path=${filePath}:${lineIndex}:${columnIndex}`;
-      //      - project is the name of the repo, e.g. "stc-23-language-Clashsoft"
-      //      - filePath is the path to the file, e.g. "src/main/java/org/example/MyClass.java"
-      //      - lineIndex and columnIndex are 0-based
-      this.openUrl = `${this.configService.get('ide')}://fulib.fulibfeedback/open?file=${encodeURIComponent(snippet.file)}&line=${snippet.from.line}&endline=${snippet.to.line}`;
     }
     if (changes.expanded) {
       this.setExpanded(changes.expanded.currentValue);

--- a/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.html
+++ b/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.html
@@ -30,7 +30,7 @@
       </div>
     }
     <app-evaluation-form [dto]="dto" [task]="task"></app-evaluation-form>
-    <app-snippet-list [dto]="dto" [task]="task"></app-snippet-list>
+    <app-snippet-list [assignment]="assignment" [solution]="solution" [dto]="dto" [task]="task"></app-snippet-list>
   </ng-container>
   <ng-container modal-footer>
     @if (codeSearchEnabled) {

--- a/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.ts
+++ b/frontend/src/app/assignment/modules/solution/evaluation-modal/evaluation-modal.component.ts
@@ -27,6 +27,8 @@ export class EvaluationModalComponent implements OnInit, OnDestroy {
   similarSolutionsEnabled = this.configService.getBool('similarSolutions');
 
   startDate = Date.now();
+  assignment?: ReadAssignmentDto;
+  solution?: Solution;
   task?: Task;
   evaluation?: Evaluation;
   dto: CreateEvaluationDto = {
@@ -65,8 +67,14 @@ export class EvaluationModalComponent implements OnInit, OnDestroy {
       share(),
     );
 
+    assignment$.subscribe(assignment => this.assignment = assignment);
+
     this.loadCodeSearchEnabled(assignment$);
     this.loadTask(assignment$);
+
+    this.route.params.pipe(
+      switchMap(({aid, sid}) => this.solutionService.get(aid, sid)),
+    ).subscribe(solution => this.solution = solution);
 
     const config = {
       codeSearch: this.codeSearchEnabled,

--- a/frontend/src/app/assignment/modules/solution/share/share.component.html
+++ b/frontend/src/app/assignment/modules/solution/share/share.component.html
@@ -41,6 +41,6 @@
   <a class="bi-gear" routerLink="/assignments/settings" ngbTooltip="Configure"></a>.
 </p>
 <a class="btn btn-primary bi-magic"
-   [href]="ide + '://fulib.fulibfeedback/configure?api_server=' + encodedApiServer + '&assignment=' + assignmentId + '&solution=' + solutionId + '&token=' + token | safeUrl">
+   [href]="ide|fulibFeedbackLink:assignmentId:solutionId:token! | safeUrl">
   Configure
 </a>

--- a/frontend/src/app/assignment/modules/solution/share/share.component.ts
+++ b/frontend/src/app/assignment/modules/solution/share/share.component.ts
@@ -4,7 +4,6 @@ import {ActivatedRoute} from '@angular/router';
 import {of} from 'rxjs';
 import {map, switchMap, tap} from 'rxjs/operators';
 import {SolutionService} from 'src/app/assignment/services/solution.service';
-import {environment} from '../../../../../environments/environment';
 import {ConfigService} from '../../../services/config.service';
 
 @Component({
@@ -19,7 +18,6 @@ export class SolutionShareComponent implements OnInit {
   ide = this.configService.get('ide');
 
   readonly origin: string;
-  readonly encodedApiServer = encodeURIComponent(new URL(environment.assignmentsApiUrl, location.origin).origin);
 
   constructor(
     private solutionService: SolutionService,
@@ -46,9 +44,5 @@ export class SolutionShareComponent implements OnInit {
     ).subscribe(token => {
       this.token = token;
     });
-  }
-
-  saveIde(value: string) {
-    this.configService.set('ide', value);
   }
 }

--- a/frontend/src/app/assignment/modules/solution/similar-modal/similar-modal.component.html
+++ b/frontend/src/app/assignment/modules/solution/similar-modal/similar-modal.component.html
@@ -61,7 +61,7 @@
                   >
                     @if (snippets[solution._id!]?.[index];as solutionSnippet) {
                       <app-edit-snippet [index]="index" [snippet]="solutionSnippet"></app-edit-snippet>
-                      <app-snippet [snippet]="solutionSnippet"></app-snippet>
+                      <app-snippet [assignment]="assignment" [solution]="solution" [snippet]="solutionSnippet"></app-snippet>
                     }
                   </td>
                 }

--- a/frontend/src/app/assignment/modules/solution/similar-modal/similar-modal.component.ts
+++ b/frontend/src/app/assignment/modules/solution/similar-modal/similar-modal.component.ts
@@ -12,6 +12,7 @@ import {forkJoin} from "rxjs";
 import {ToastService} from "@mean-stream/ngbx";
 import {EvaluationService} from "../../../services/evaluation.service";
 import {EmbeddingService} from "../../../services/embedding.service";
+import {ReadAssignmentDto} from "../../../model/assignment";
 
 @Component({
   selector: 'app-similar-modal',
@@ -19,6 +20,7 @@ import {EmbeddingService} from "../../../services/embedding.service";
   styleUrls: ['./similar-modal.component.scss']
 })
 export class SimilarModalComponent implements OnInit {
+  assignment?: ReadAssignmentDto;
   solutionId!: string;
   task?: Task;
   evaluation?: Evaluation;
@@ -54,10 +56,11 @@ export class SimilarModalComponent implements OnInit {
     this.route.params.subscribe(({sid}) => this.solutionId = sid);
 
     this.route.params.pipe(
-      switchMap(({aid, task}) => this.assignmentService.get(aid).pipe(
-        map(assignment => this.taskService.find(assignment.tasks, task)),
-      )),
-    ).subscribe(task => this.task = task);
+      switchMap(({aid}) => this.assignmentService.get(aid)),
+    ).subscribe(assignment => {
+      this.assignment = assignment;
+      this.task = this.taskService.find(assignment.tasks, this.route.snapshot.params.task);
+    });
 
     // load solution IDs that already have an evaluation for this task
     this.route.params.pipe(

--- a/frontend/src/app/assignment/modules/solution/snippet-list/snippet-list.component.html
+++ b/frontend/src/app/assignment/modules/solution/snippet-list/snippet-list.component.html
@@ -38,7 +38,7 @@
 </ul>
 <div class="form-text">
   Use
-  <a href="https://marketplace.visualstudio.com/items?itemName=fulib.fulibFeedback" target="_blank">
+  <a href="https://github.com/fujaba/fulibFeedback" target="_blank">
     fulibFeedback
   </a>
   to add code snippets from within your IDE.

--- a/frontend/src/app/assignment/modules/solution/snippet-list/snippet-list.component.html
+++ b/frontend/src/app/assignment/modules/solution/snippet-list/snippet-list.component.html
@@ -26,7 +26,13 @@
         [snippet]="snippet" [index]="$index" [comments]="comments"
         (deleted)="deleteSnippet($index)"
       ></app-edit-snippet>
-      <app-snippet [snippet]="snippet" wildcard="***" (updated)="snippetUpdates$.next($event)"></app-snippet>
+      <app-snippet
+        [assignment]="assignment"
+        [solution]="solution"
+        [snippet]="snippet"
+        wildcard="***"
+        (updated)="snippetUpdates$.next($event)"
+      ></app-snippet>
     </li>
   }
 </ul>
@@ -52,7 +58,13 @@
   <ul class="list-group" id="embedding-snippets">
     @for (snippet of embeddingSnippets;track snippet) {
       <li class="list-group-item">
-        <app-snippet [snippet]="snippet" [expanded]="$first" (confirmed)="confirmEmbedding(snippet)"></app-snippet>
+        <app-snippet
+          [assignment]="assignment"
+          [solution]="solution"
+          [snippet]="snippet"
+          [expanded]="$first"
+          (confirmed)="confirmEmbedding(snippet)"
+        ></app-snippet>
       </li>
     }
   </ul>

--- a/frontend/src/app/assignment/modules/solution/snippet-list/snippet-list.component.ts
+++ b/frontend/src/app/assignment/modules/solution/snippet-list/snippet-list.component.ts
@@ -10,6 +10,8 @@ import {EvaluationService} from "../../../services/evaluation.service";
 import {EmbeddingService} from "../../../services/embedding.service";
 import {ActivatedRoute} from "@angular/router";
 import Task from "../../../model/task";
+import Solution from "../../../model/solution";
+import {ReadAssignmentDto} from "../../../model/assignment";
 
 export const selectionComment = '(fulibFeedback Selection)';
 
@@ -19,6 +21,8 @@ export const selectionComment = '(fulibFeedback Selection)';
   styleUrls: ['./snippet-list.component.scss']
 })
 export class SnippetListComponent implements OnInit, OnDestroy {
+  @Input({required: true}) assignment?: ReadAssignmentDto;
+  @Input({required: true}) solution?: Solution;
   @Input({required: true}) task?: Task;
   @Input({required: true}) dto: CreateEvaluationDto;
 


### PR DESCRIPTION
## New Features

+ Added support for IntelliJ IDEA, PyCharm and WebStorm as possible IDEs. [fulibFeedback#3](https://github.com/fujaba/fulibFeedback/issues/3)

Note that the [IntelliJ Plugin](https://plugins.jetbrains.com/plugin/23254-fulibfeedback) is not yet publicly available as of 2023-01-01.