### PR TITLE
Fix lost properties like note when converting task list to markdown and back

### DIFF
--- a/frontend/src/app/assignment/modules/edit-assignment/task-markdown.service.ts
+++ b/frontend/src/app/assignment/modules/edit-assignment/task-markdown.service.ts
@@ -21,12 +21,12 @@ export class TaskMarkdownService {
         continue;
       }
 
-      const {prefix, description, points, _id, glob} = extractTaskItem(match);
+      // exclude __proto__ from rest to avoid prototype pollution
+      const {prefix, points, _id, __proto__, ...rest} = extractTaskItem(match);
       const task: Task = {
+        ...rest,
         _id: _id || this.taskService.generateID(),
         points: +points,
-        description,
-        glob,
         children: [],
         collapsed: true,
       };


### PR DESCRIPTION
## Bugfixes

* When switching the task editor to markdown and back, extra information like Evaluation Notes is no longer lost. #435 

Closes #435 